### PR TITLE
Fix: crash when generating `random number`

### DIFF
--- a/src/lib/numbers.rs
+++ b/src/lib/numbers.rs
@@ -14,7 +14,7 @@ pub fn get_random_number(num1: i32) -> i32 {
 pub fn get_random_number_between(num1: i32, num2: i32) -> i32 {
     let min = std::cmp::min(num1, num2);
     let max = std::cmp::max(num1, num2);
-    return rand::thread_rng().gen_range(min..max);
+    return rand::thread_rng().gen_range(min..=max);
 }
 
 //  -----


### PR DESCRIPTION
with `min` and `max` set to the same value

Fixes #31